### PR TITLE
** add info file

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,8 @@
+#lang info
+(define collection "recess")
+(define deps '("base" "draw-lib" "graph" "gui-lib" "htdp-lib" "lux" "mode-lambda" "pict-lib" "raart" "struct-define"))
+(define build-deps '("scribble-lib" "racket-doc"))
+(define pkg-desc "TBA")
+(define version "0.1")
+(define pkg-authors '(chike))
+(define compile-omit-paths '("examples"))


### PR DESCRIPTION
With this info file, I'm able to run `raco setup recess` with no errors.

I'm not sure if the `"examples"` folder should be omitted or not. For now, it doesn't compile for me. I get errors including this one:
```
raco setup: error: during making for <pkgs>/recess/examples/fishy-fishy-cross-my-ocean
raco setup:   examples/fishy-fishy-cross-my-ocean/fishy-systems.rkt:79:44: set!: bad syntax
raco setup:     in: (set! e (random OCEAN) (quote Guess))
raco setup:     compiling: <pkgs>/recess/examples/fishy-fishy-cross-my-ocean/fishy-systems.rkt
raco setup: error: during making for <pkgs>/recess/examples/fishy-fishy-cross-my-ocean
```